### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ node_modules
 # Vagrant
 bin
 .vagrant
+
+# OS X
+.DS_Store


### PR DESCRIPTION
This PR adds `.DS_Store` to `.gitignore` so these useless files that OS X generates don't get checked in. 